### PR TITLE
[GITHUB-5] Allow mounting "nvme1n1" volumes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ sudo: required
 language: python
 python:
   - 2.7
+cache: pip
 
 branches:
   only:
@@ -14,9 +15,10 @@ branches:
     - master
 
 env:
-  - ANSIBLE_INSTALL_VERSION=2.3.3.0
-  - ANSIBLE_INSTALL_VERSION=2.4.4.0
-  - ANSIBLE_INSTALL_VERSION=2.5.3
+  - ANSIBLE_INSTALL_VERSION=2.4.6.0
+  - ANSIBLE_INSTALL_VERSION=2.5.11
+  - ANSIBLE_INSTALL_VERSION=2.6.7
+  - ANSIBLE_INSTALL_VERSION=2.7.1
 
 services:
   - docker
@@ -26,7 +28,7 @@ before_install:
   - sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-ce
 
 install:
-  - make .venv_ansible${ANSIBLE_INSTALL_VERSION}
+  - make .venv
 
 script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ANSIBLE_INSTALL_VERSION ?= 2.5.3.0
+ANSIBLE_INSTALL_VERSION ?= 2.6.7
 PATH := $(PWD)/.venv_ansible$(ANSIBLE_INSTALL_VERSION)/bin:$(shell printenv PATH)
 SHELL := env PATH=$(PATH) /bin/bash
 
@@ -35,14 +35,20 @@ destroy:
 		echo -e "\033[0;33mWARNING: molecule not found - either remove potential containers manually or run 'make deps' first\033[0m"; \
 	fi
 
+
 ## Login to docker container named '%'
 login_%: .venv_ansible$(ANSIBLE_INSTALL_VERSION)
 	@echo -e "\033[0;32mINFO: Logging into $(subst login_,,$@) (ctrl-d to exit)\033[0m"
 	@.venv_ansible$(ANSIBLE_INSTALL_VERSION)/bin/molecule login --host $(subst login_,,$@)
 
+
 ## Run 'molecule test --destroy=never' (run 'make destroy' to destroy containers)
 test: .venv_ansible$(ANSIBLE_INSTALL_VERSION)
 	@.venv_ansible$(ANSIBLE_INSTALL_VERSION)/bin/molecule test --destroy=never
+
+
+# shortcut for making virtualenv
+.venv: .venv_ansible$(ANSIBLE_INSTALL_VERSION)
 
 
 ## Create virtualenv, install dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,8 @@ sansible_persistent_volumes_ensure_directories: []
 sansible_persistent_volumes_device:
   # The linux device path where the block device is expected to appear.
   path: /dev/xvdb
+  # ec2_vol does not recognise `/dev/nvme1n1` as valid path.
+  ec2_vol_path: /dev/xvdb
   # Filesystem type.
   fs_type: ext4
   # The group id that should be applied on the mount point.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-docker-py
-flake8
-molecule
-yamllint
+docker-py==1.10.6
+molecule==2.19.0
+# there is a bug with cache in latest 3.10.0
+pytest==3.9.3

--- a/tasks/configure/assigned_volume.yml
+++ b/tasks/configure/assigned_volume.yml
@@ -10,14 +10,16 @@
   delay: "{{ sansible_persistent_volumes_task.delay }}"
   until:
     - assigned_volume_ec2_instance_tags is succeeded
-    - sansible_persistent_volumes_aws.assigned_volume_instance_tag in assigned_volume_ec2_instance_tags.tags
+    - sansible_persistent_volumes_aws.assigned_volume_instance_tag
+      in assigned_volume_ec2_instance_tags.tags
 
 - name: Assigned volume ensure EBS volume not mounted on instance
   ec2_vol_facts:
     filters:
       attachment.instance-id: "{{ ansible_ec2_instance_id }}"
       status: in-use
-      volume-id: "{{ assigned_volume_ec2_instance_tags.tags[sansible_persistent_volumes_aws.assigned_volume_instance_tag] }}"
+      volume-id: "{{ assigned_volume_ec2_instance_tags.tags[
+        sansible_persistent_volumes_aws.assigned_volume_instance_tag] }}"
     region: "{{ ansible_ec2_placement_region }}"
   register: assigned_volume_mount_facts
   until: assigned_volume_mount_facts is succeeded
@@ -26,8 +28,9 @@
 
 - name: Assigned volume connect available EBS volume
   ec2_vol:
-    device_name: "{{ sansible_persistent_volumes_device.path }}"
-    id: "{{ assigned_volume_ec2_instance_tags.tags[sansible_persistent_volumes_aws.assigned_volume_instance_tag] }}"
+    device_name: "{{ sansible_persistent_volumes_device.ec2_vol_path }}"
+    id: "{{ assigned_volume_ec2_instance_tags.tags[
+      sansible_persistent_volumes_aws.assigned_volume_instance_tag] }}"
     instance: "{{ ansible_ec2_instance_id }}"
     region: "{{ ansible_ec2_placement_region }}"
   when: assigned_volume_mount_facts.volumes[0] is not defined

--- a/tasks/configure/tagged_volume.yml
+++ b/tasks/configure/tagged_volume.yml
@@ -3,7 +3,7 @@
 - name: Tagged volume ensure EBS volume not mounted on instance
   ec2_vol_facts:
     filters: "{{
-      persistent_volumes.aws.tagged_volume_lookup_filters | combine( {
+      sansible_persistent_volumes_aws.tagged_volume_lookup_filters | combine( {
         'attachment.instance-id': ansible_ec2_instance_id,
         'availability-zone': ansible_ec2_placement_availability_zone,
         'status': 'in-use'
@@ -18,7 +18,7 @@
 - name: Tagged volume lookup available EBS volume
   ec2_vol_facts:
     filters: "{{
-      persistent_volumes.aws.tagged_volume_lookup_filters | combine( {
+      sansible_persistent_volumes_aws.tagged_volume_lookup_filters | combine( {
         'availability-zone': ansible_ec2_placement_availability_zone,
         'status': 'available'
       } )
@@ -34,7 +34,7 @@
   ec2_vol:
     id: "{{ tagged_volume_facts.volumes[0].id }}"
     instance: "{{ ansible_ec2_instance_id }}"
-    device_name: "{{ persistent_volumes.device }}"
+    device_name: "{{ sansible_persistent_volumes_device.path }}"
     region: "{{ ansible_ec2_placement_region }}"
   when: tagged_volume_mount_facts.volumes[0] is not defined
   register: tagged_volume_connect


### PR DESCRIPTION
When mouning on network enhanced ec2 box, the device path is in format
`/dev/nvme1n1` which is invalid for "ec2_vol" module.

When mounting on Network Enhanced machine, use:

```YAML
sansible_persistent_volumes_device:
  path: /dev/nvme1n1
```

... and it will appear in AWS console as `/dev/xvdb/`.